### PR TITLE
Quit with exit code 1 in case of error

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,9 +44,8 @@ func main() {
             // Message from an error.
             fmt.Println(err.Error())
         }
-        return
+        os.Exit(1)
     }
 
     fmt.Println(result)
 }
-


### PR DESCRIPTION
I noticed my build passing although an error had occurred. As drone build steps fail for non-zero exit codes, I replaced the simple `return` statement with an `os.Exit(1)`